### PR TITLE
Check HDR mode supported

### DIFF
--- a/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice+AVCaptureDevice.swift
+++ b/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice+AVCaptureDevice.swift
@@ -19,6 +19,7 @@ extension AVCaptureDevice: CaptureDevice {
     var maxISO: Float { activeFormat.maxISO }
     var minFrameRate: Float64? { activeFormat.videoSupportedFrameRateRanges.first?.minFrameRate }
     var maxFrameRate: Float64? { activeFormat.videoSupportedFrameRateRanges.first?.maxFrameRate }
+    var isVideoHDRSupported: Bool { activeFormat.isVideoHDRSupported }
 }
 
 // MARK: Getters & Setters
@@ -34,6 +35,7 @@ extension AVCaptureDevice {
             else { return .off }
         }
         set {
+            guard isVideoHDRSupported else { return }
             automaticallyAdjustsVideoHDREnabled = newValue == .auto
             if newValue != .auto { isVideoHDREnabled = newValue == .on }
         }

--- a/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice+MockCaptureDevice.swift
+++ b/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice+MockCaptureDevice.swift
@@ -31,6 +31,7 @@ class MockCaptureDevice: NSObject, CaptureDevice {
     var hasTorch: Bool { true }
     var isExposurePointOfInterestSupported: Bool { true }
     var isFocusPointOfInterestSupported: Bool { true }
+    var isVideoHDRSupported: Bool { true }
 
     // MARK: Setters
     var videoZoomFactor: CGFloat = 1

--- a/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice.swift
+++ b/Sources/Internal/Manager/Helpers/Capture Device/CaptureDevice.swift
@@ -31,6 +31,7 @@ protocol CaptureDevice: NSObject {
     var hasTorch: Bool { get }
     var isExposurePointOfInterestSupported: Bool { get }
     var isFocusPointOfInterestSupported: Bool { get }
+    var isVideoHDRSupported: Bool { get }
 
     // MARK: Getters & Setters
     var videoZoomFactor: CGFloat { get set }


### PR DESCRIPTION
Check HDR mode supported just like any other mode.

I got this error:

```
*** -[AVCaptureDevice setVideoHDREnabled:] Not supported - use activeFormat.isVideoHDRSupported
```

On  iPhone X (CDMA) (iPhone10,3).